### PR TITLE
Give the context function the location as an argument when running in the browser

### DIFF
--- a/src/create.browser.js
+++ b/src/create.browser.js
@@ -26,7 +26,7 @@ function createApp({ routes, history, context, container, onRenderComplete }) {
       query: location.query,
       hash: location.hash,
       history,
-      ...(context instanceof Function ? context() : context),
+      ...(context instanceof Function ? context(location) : context),
     };
     try {
       result = await match(routes, ctx);


### PR DESCRIPTION
In the browser `createApp` function, if a context generating function is passed, it will be given the new `location` descriptor as an argument whenever `history.listen` detects a change.

This mirrors the passing of the Node `request` object into the context generating function on the server side.

This means we can create context generating functions on the client-side (based on the `location` object) and the server-side (based on the Node `request`). These functions can perform the task of normalising the context presented to the application.

As an example use case, this allows integration with [react-router-form](https://github.com/insin/react-router-form) (an isomorphic/universal form component). This form component handles submitting of the form in two ways:
- When Javascript is not available, it will submit the form using normal HTTP with the following forming part of the HTTP request sent by the browser (as seen by Node):
  - `request.method` - the forms HTTP method
  - `request.body` - the forms content
- When Javascript is available, it will change the location using `history.push` filling the `location.state` with the properties:
  - `location.state.method` - the forms HTTP method
  - `location.state.body` - the forms content

We can then make context normalising functions on the client and server to give a consistent view of the request to the application:

```
let client_context = function(loc) {
    return {
        request: {
            method: (loc.state === null) ? 'GET' : loc.state.method,
            body:   (loc.state === null) ? {}    : loc.state.body
        }
    }
}
```

```
let server_context = function(req) {
    return {
        request: {
            method: req.method || 'GET',
            body: req.body || {}
        }
    }
}
```

I think this change is general enough to be useful for a variety of other use cases. And presents a consistent interface (presenting `request` on the server-side, and it's analogue `location` on the client-side).

Thanks, 
Dan
